### PR TITLE
修复 checkbox, radio, gitlab 标签 bug；使 fold 标签支持 markdown 内容；使 note 标签在深色模式下可以正常阅读 

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -436,7 +436,7 @@ export function gitlabTag([repo]: str) {
   </div>
   <img class='lang-${id} repo-language no-lightbox' />
   <script>
-    fetch('https://gitlab.com/api/v4/projects/${repo}')
+    fetch('https://gitlab.com/api/v4/projects/${encodeURIComponent(repo)}')
       .then(res => res.json())
       .then(data => {
         document.querySelector('.name-${id}').innerText = data.name;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -316,7 +316,7 @@ export function noteTag([cls, icon]: str2 | string, content: string) {
     cls += ' no-icon';
   }
   // @ts-ignore
-  return htmlTag('div', {class: `note ${cls}`}, (icon ? htmlTag('i', {class: `solitude ${icon}`}, '', false) : '') + hexo.render.renderSync({
+  return htmlTag('div', {class: `note ${cls} modern`}, (icon ? htmlTag('i', {class: `solitude ${icon}`}, '', false) : '') + hexo.render.renderSync({
     text: content,
     engine: 'markdown'
   }).trim(), false);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -275,11 +275,11 @@ export function checkboxTag([style, checked, content]: str3 | str2) {
     content = checked;
     checked = 'checked';
   }
-  return htmlTag('div', {class: 'checkbox'}, htmlTag('input', {
-    type: 'checkbox',
-    checked,
-    style
-  }, content, false), false);
+  return htmlTag('div', {class: 'checkbox ' + style},
+    `<input type="checkbox" ${ checked==='unchecked' ? '' : `checked=${checked}` }/>${
+    // @ts-ignore
+    hexo.render.renderSync({text: content, engine: 'markdown'}).split('\n').join('')
+    }`, false);
 }
 
 /**
@@ -294,11 +294,11 @@ export function radioTag([style, checked, content]: str3 | str2) {
     content = checked;
     checked = 'checked';
   }
-  return htmlTag('div', {class: 'checkbox'}, htmlTag('input', {
-    type: 'radio',
-    checked,
-    style
-  }, content, false), false);
+  return htmlTag('div', {class: 'checkbox ' + style},
+    `<input type="radio" ${ checked==='unchecked' ? '' : `checked=${checked}` }/>${
+    // @ts-ignore
+    hexo.render.renderSync({text: content, engine: 'markdown'}).split('\n').join('')
+    }`, false);
 }
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -156,7 +156,11 @@ export function pTag([cls, text]: str2) {
  */
 export function foldTag([title, open]: str2, content) {
   _fold = true;
-  return htmlTag('details', {open}, htmlTag('summary', {}, title, false) + content, false);
+  // @ts-ignore
+  return htmlTag('details', { open }, htmlTag('summary', {}, title, false) + hexo.render.renderSync({
+    text: content,
+    engine: 'markdown'
+  }).trim(), false);
 }
 
 /**


### PR DESCRIPTION
Bug fix:
- 修复 checkbox 与 radio 标签的 `style` 信息存放位置错误，导致不能正常应用 `style` 参数的 bug
- 修复 checkbox 与 radio 标签由于样式文件中只判定 `checked` 属性是否存在，导致不能正常应用 `checked` 参数的 bug
- 修复 gitlab 标签由于以错误方式调用 api，导致不能正常获取仓库信息的 bug

Feature:
- 使 fold 标签内容支持 markdown 语法
- 使 note 标签中的文字在深色模式下也能看清