### PR TITLE
新增气泡注释、键盘按键、剧透文本标签

### DIFF
--- a/lib/css/bubble.styl
+++ b/lib/css/bubble.styl
@@ -1,0 +1,33 @@
+.bubble-content
+  display inline-block
+  color var(--efu-lighttext)
+  font-weight bold
+  transition: all 0.2s ease-in-out
+  text-shadow: var(--efu-shadow-theme)
+  border-bottom: 2px dotted var(--efu-lighttext);
+  &:hover
+    transition: all 0.2s ease-in-out
+    color: var(--efu-hovertext)
+
+    & + .bubble-notation
+      .bubble-item
+        transform translate(-40px, 10px) rotateX(0deg)
+        transition: all 0.5s ease-in-out
+        opacity: 1
+
+.bubble-notation
+  display: inline-block
+
+.bubble-item
+  transition: all 0.5s ease-in-out
+  opacity 0
+  z-index: 99
+  display flex
+  position absolute
+  transform translate(-40px, 10px) rotateX(90deg)
+  width auto
+  height auto
+  max-width 400px
+  overflow hidden
+  padding 20px 10px 10px 10px
+  clip-path polygon(5px 10px,20px 10px,30px 0,40px 10px,calc(100% - 5px) 10px,100% 15px,100% calc(100% - 5px),calc(100% - 5px) 100%,5px 100%,0 calc(100% - 5px),0 15px,5px 10px)

--- a/lib/css/index.styl
+++ b/lib/css/index.styl
@@ -34,6 +34,9 @@ if $tag_repo
 if $tag_bubble
   @import "bubble.styl"
 
+if $tag_keyboard
+  @import "keyboard.styl"
+
 .red
   color var(--efu-red)
 

--- a/lib/css/index.styl
+++ b/lib/css/index.styl
@@ -31,6 +31,9 @@ if $tag_button
 if $tag_repo
   @import "repo.styl"
 
+if $tag_bubble
+  @import "bubble.styl"
+
 .red
   color var(--efu-red)
 

--- a/lib/css/index.styl
+++ b/lib/css/index.styl
@@ -37,6 +37,9 @@ if $tag_bubble
 if $tag_keyboard
   @import "keyboard.styl"
 
+if $tag_spoiler
+  @import "spoiler.styl";
+
 .red
   color var(--efu-red)
 

--- a/lib/css/keyboard.styl
+++ b/lib/css/keyboard.styl
@@ -1,0 +1,11 @@
+.keyboard
+  border 1px solid var(--efu-secondbg)
+  font-size 0.7em
+  box-shadow 1px 0 1px 0 #eee, 0 2px 0 2px #ccc, 0 2px 0 3px #444
+  -webkit-border-radius 3px
+  -moz-border-radius 3px
+  border-radius 3px
+  margin 2px 3px
+  padding 1px 5px
+  position relative
+  top -1.5px

--- a/lib/css/spoiler.styl
+++ b/lib/css/spoiler.styl
@@ -1,0 +1,23 @@
+.spoiler
+  &.blur-text
+    filter blur(3px) !important
+    padding 5px
+    cursor default
+    user-select none !important
+    transition filter 0.4s ease 0.15s
+
+    &:hover, &:focus
+      user-select auto !important
+      filter blur(0) !important
+
+  &.block-text
+    background-color var(--efu-fontcolor) !important
+    color transparent !important
+    cursor default
+    user-select none !important
+    transition background-color 0.4s ease 0.15s, color 0.3s ease 0.15s
+
+    &:hover, &:focus
+      color inherit !important
+      user-select auto !important
+      background-color var(--efu-theme-op) !important

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,6 +45,8 @@ hexo.extend.tag.register('gitlab', gitlabTag);
 hexo.extend.tag.register('gitee', giteeTag);
 // @ts-ignore
 hexo.extend.tag.register('gitea', giteaTag);
+// @ts-ignore
+hexo.extend.tag.register('bubble', bubbleTag);
 
 
 let _span = false;
@@ -58,6 +60,7 @@ let _timeline = false;
 let _media = false;
 let _button = false;
 let _repo = false;
+let _bubble = false;
 // @ts-ignore
 hexo.extend.filter.register('stylus:renderer', (style: any) => {
   style
@@ -72,6 +75,7 @@ hexo.extend.filter.register('stylus:renderer', (style: any) => {
     .define('$tag_media', _media)
     .define('$tag_button', _button)
     .define('$tag_repo', _repo)
+    .define('$tag_bubble', _repo)
     .import(path.join(__dirname, 'css', 'index.styl'));
 });
 
@@ -520,4 +524,30 @@ export function giteaTag([server, repo]: str2) {
   </script>
   `
   , false);
+}
+
+/**
+ * Bubble notation tag
+ *
+ * Syntax:
+ * {% bubble content notation background-color %}
+ */
+export function bubbleTag([content, notation, color]: str3) {
+  _bubble = true;
+  if (typeof color === 'undefined')
+    color = 'blue';
+  if (color.startsWith('#')) {
+    const r = parseInt(color.slice(1, 3), 16) / 255;
+    const g = parseInt(color.slice(3, 5), 16) / 255;
+    const b = parseInt(color.slice(5, 7), 16) / 255;
+    const brightness = 0.5474 * Math.sqrt((r ** 2) + (1.5 * g) ** 2 + (0.6 * b) ** 2); // 亮度计算近似公式
+    return htmlTag('span', { class: 'bubble-content' }, content, false) + htmlTag('span', { class: 'bubble-notation' },
+      htmlTag('span', {
+        class: 'bubble-item',
+        style: `background-color:${color}; color: ${brightness > 0.5 ? 'var(--efu-black)' : 'var(--efu-white)'}`
+      }, notation, false), false)
+  } else {
+    return htmlTag('span', { class: 'bubble-content' }, content, false) + htmlTag('span', { class: 'bubble-notation' },
+      htmlTag('span', { class: `bubble-item bg-${color}` }, notation, false), false)
+  }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -49,6 +49,8 @@ hexo.extend.tag.register('gitea', giteaTag);
 hexo.extend.tag.register('bubble', bubbleTag);
 // @ts-ignore
 hexo.extend.tag.register('keyboard', keyboardTag);
+// @ts-ignore
+hexo.extend.tag.register('spoiler', spoilerTag);
 
 
 let _span = false;
@@ -64,6 +66,7 @@ let _button = false;
 let _repo = false;
 let _bubble = false;
 let _keyboard = false;
+let _spoiler = false;
 // @ts-ignore
 hexo.extend.filter.register('stylus:renderer', (style: any) => {
   style
@@ -80,6 +83,7 @@ hexo.extend.filter.register('stylus:renderer', (style: any) => {
     .define('$tag_repo', _repo)
     .define('$tag_bubble', _bubble)
     .define('$tag_keyboard', _keyboard)
+    .define('$tag_spoiler', _spoiler)
     .import(path.join(__dirname, 'css', 'index.styl'));
 });
 
@@ -556,7 +560,12 @@ export function bubbleTag([content, notation, color]: str3) {
   }
 }
 
-
+/**
+ * Keyboard tag
+ *
+ * Syntax:
+ * {% keyboard key %}
+ */
 export function keyboardTag([key]: str) {
   _keyboard = true
   key = key.toLowerCase()
@@ -583,3 +592,16 @@ export function keyboardTag([key]: str) {
   key = key[0].toUpperCase() + key.slice(1)
   return htmlTag("span", {class: "keyboard"}, key, false)
 }
+
+/**
+ * Spoiler text tag
+ *
+ * Syntax:
+ * {% spoiler style content %}
+ */
+export function spoilerTag([style, content]: str2) {
+  _spoiler = true
+  // @ts-ignore
+  return htmlTag("span", { class: `spoiler ${style}-text` }, content, false)
+}
+

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,6 +47,8 @@ hexo.extend.tag.register('gitee', giteeTag);
 hexo.extend.tag.register('gitea', giteaTag);
 // @ts-ignore
 hexo.extend.tag.register('bubble', bubbleTag);
+// @ts-ignore
+hexo.extend.tag.register('keyboard', keyboardTag);
 
 
 let _span = false;
@@ -61,6 +63,7 @@ let _media = false;
 let _button = false;
 let _repo = false;
 let _bubble = false;
+let _keyboard = false;
 // @ts-ignore
 hexo.extend.filter.register('stylus:renderer', (style: any) => {
   style
@@ -75,7 +78,8 @@ hexo.extend.filter.register('stylus:renderer', (style: any) => {
     .define('$tag_media', _media)
     .define('$tag_button', _button)
     .define('$tag_repo', _repo)
-    .define('$tag_bubble', _repo)
+    .define('$tag_bubble', _bubble)
+    .define('$tag_keyboard', _keyboard)
     .import(path.join(__dirname, 'css', 'index.styl'));
 });
 
@@ -550,4 +554,32 @@ export function bubbleTag([content, notation, color]: str3) {
     return htmlTag('span', { class: 'bubble-content' }, content, false) + htmlTag('span', { class: 'bubble-notation' },
       htmlTag('span', { class: `bubble-item bg-${color}` }, notation, false), false)
   }
+}
+
+
+export function keyboardTag([key]: str) {
+  _keyboard = true
+  key = key.toLowerCase()
+  switch (key) {
+    case "enter":
+      key += "↵";
+      break;
+    case "shift":
+      key += "⇧";
+      break;
+    case "windows":
+    case "window":
+    case "win":
+      key = "win"
+    case "command":
+      key += "⌘";
+      break;
+    case "option":
+      key += "⌥";
+      break;
+    default:
+      break;
+  }
+  key = key[0].toUpperCase() + key.slice(1)
+  return htmlTag("span", {class: "keyboard"}, key, false)
 }


### PR DESCRIPTION
新增三个标签。

### 使用方法
```md
{% bubble [文字] [注释] [颜色] %}
{% keyboard [按键] %}
{% spoiler [样式] [文字] %}
```
### 参数说明
#### bubble
+ [文字]：显示的文字内容
+ [注释]：气泡内显示的文字内容（不支持 Markdown 语法）
+ [颜色]：气泡的背景颜色
  - 可用颜色：`red | green | blue | yellow | pink | purple | orange`
  - 也可使用十六进制颜色，如 `#ec5830`
  - 使用自定义颜色时，气泡内的文字颜色会根据给定的背景颜色计算近似亮度，以此设置为白色 / 黑色
#### keyboard
+ [按键]：按键内文字，`Enter | Windows | Command | Option` 键会附带特殊图标
#### spoiler
+ [样式]：剧透文本遮罩类型，`blur | block`
+ [文字]：遮罩的文字内容（不支持 Markdown 语法）