### PR TITLE
修改样式引入方式，仅在 index.css 中添加标签插件的样式

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {htmlTag} from 'hexo-util';
+import stylus from 'stylus';
 
 // @ts-ignore
 hexo.extend.tag.register('youtube', youtubeTag);
@@ -65,8 +66,9 @@ let _bubble = false;
 let _keyboard = false;
 let _spoiler = false;
 // @ts-ignore
-hexo.extend.filter.register('stylus:renderer', (style: any) => {
-  style
+hexo.extend.filter.register('after_render:css', (css, data) => {
+  if (!data.path.endsWith('source\\css\\index.styl')) return css;
+  const rendered_css = stylus('')
     .define('$tag_span', _span)
     .define('$tag_fold', _fold)
     .define('$tag_link', _link)
@@ -80,7 +82,9 @@ hexo.extend.filter.register('stylus:renderer', (style: any) => {
     .define('$tag_bubble', _bubble)
     .define('$tag_keyboard', _keyboard)
     .define('$tag_spoiler', _spoiler)
-    .import(path.join(__dirname, 'css', 'index.styl'));
+    .import(path.join(__dirname, 'css', 'index.styl'))
+    .render();
+  return css.replace('@charset "UTF-8";', `@charset "UTF-8";\n${rendered_css}`);
 });
 
 type str = [string];

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/chai": "^4.3.17",
     "@types/mocha": "^10.0.7",
     "@types/node": "^18.19.44",
+    "@types/stylus": "^0.48.43",
     "c8": "^8.0.1",
     "chai": "^4.5.0",
     "cheerio": "1.0.0-rc.12",
@@ -42,6 +43,7 @@
     "hexo": "^7.3.0",
     "hexo-renderer-marked": "^6.3.0",
     "mocha": "^10.7.3",
+    "stylus": "^0.64.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
   },


### PR DESCRIPTION
之前的样式引入方式会为所有 stylus 渲染的 css 都添加标签插件的样式代码，例如在博客的 source 中使用 stylus 来编写自定义的样式时，该自定义样式也被添加了标签插件的样式代码。

修改后可以判断 styl 源文件路径，只修改主题的 index.styl 所渲染的 index.css。