### PR TITLE
fix: 样式引入路径跨平台问题， card 标签 stylus 变量定义缺失问题

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -69,7 +69,7 @@ let _spoiler = false;
 let _card = false;
 // @ts-ignore
 hexo.extend.filter.register('after_render:css', (css, data) => {
-  if (!data.path.endsWith('source\\css\\index.styl')) return css;
+  if (!data.path.endsWith(path.join('source', 'css', 'index.styl'))) return css;
   const rendered_css = stylus('')
     .define('$tag_span', _span)
     .define('$tag_fold', _fold)
@@ -84,6 +84,7 @@ hexo.extend.filter.register('after_render:css', (css, data) => {
     .define('$tag_bubble', _bubble)
     .define('$tag_keyboard', _keyboard)
     .define('$tag_spoiler', _spoiler)
+    .define('$tag_card', _card)
     .import(path.join(__dirname, 'css', 'index.styl'))
     .render();
   return css.replace('@charset "UTF-8";', `@charset "UTF-8";\n${rendered_css}`);
@@ -571,7 +572,7 @@ export function keyboardTag([key]: str) {
     case 'window':
     case 'win':
       key = 'win';
-      break;
+      // fallthrough
     case 'command':
       key += '⌘';
       break;


### PR DESCRIPTION
主要是对上个 PR 一些问题的修复。

- 修复样式引入时，路径字符串硬编码导致的跨平台兼容问题
- 补上因为上个 PR 的 merge 时间较晚导致的 card 标签 stylus 变量定义缺失
- 改用 //fallthrough 来保证 keyboard 标签中 win 键也被添加上特殊图标